### PR TITLE
Docker Hub Documentation Fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Pull Request
+
+## Description
+
+Provide a description of the pull request.
+
+## Tests
+
+Provide links to tests.
+
+## Related Issues
+
+List of related issues.
+
+## Maintainer Use Only
+
+- [ ] Suitable tests are passing.
+- [ ] Release version bumped in `Makefile`
+- [ ] New change log generated (`make changelog`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@ List of related issues.
 
 ## Maintainer Use Only
 
+Changes to the code for these steps should be committed with a message
+similar to `chg: doc: Release X.Y.Z [skip ci], !minor` so that CI tests are
+skipped for these minor changes and also don't appear in the change log.
+
 - [ ] Suitable tests are passing.
 - [ ] Release version bumped in `Makefile`
 - [ ] New change log generated (`make changelog`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@
 name: CI
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.0.1
+## 1.0.3
+
+### Fix
+
+* Allow CI build to be skipped. [Ben Dalling]
+
+* Resolve bad link issue. [Ben Dalling]
+
+* Migrate from GitFlow to GitHub Flow. [Ben Dalling]
+
+
+## 1.0.1 (2021-01-03)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.0.1
+TAG = 1.0.3
 
 all: lint build test
 
@@ -23,6 +23,9 @@ push: build
 	echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
 	docker push cbdq/docker-grype:$(TAG)
 	docker push cbdq/docker-grype:latest
+
+tag:
+	git tag -a -m"v$(TAG)" $(TAG)
 
 test:
 	docker-compose -f tests/resources/docker-compose.yml up -d docker grype

--- a/README.md
+++ b/README.md
@@ -12,17 +12,47 @@ Wrap [Anchore Grype](https://github.com/anchore/grype) Inside Docker
   `Medium`, `High` or `Critical`.
 - `VULNERABILITIES_ALLOWED_LIST` (optional): A comma separated list of vulnerabilities that are not to count against
   a failure (e.g. `CVE-2018-20225,CVE-2020-29363`).
-  
+
 ## Examples
 
 ### Docker Compose
 
-Tested on Ubuntu.  The file [examples/docker-compose.yml](examples/docker-compose.yml) contains
+Tested on Ubuntu.  This snippet contains
 an example configuration that will test the `hello-world:latest` image.
+
+```YAML
+---
+version: "3"
+
+services:
+  docker:
+    container_name: docker
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+    image: docker:18-dind
+    privileged: yes
+    volumes:
+      - certs:/certs/client
+      - ../..:/work
+    working_dir: /work
+
+  grype:
+    container_name: grype
+    depends_on:
+      - docker
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_TLS_CERTDIR: ""
+      IMAGE_NAME: hello-world:latest
+    image: cbdq/docker-grype:latest
+
+volumes:
+  certs:
+```
 
 This could be used by running the command (in the same directory as the
 `docker-compose.yml` file):
 
-```
+```shell
 docker-compose run grype
 ```


### PR DESCRIPTION
# Pull Request

## Description

Replace the broken link with an example snippet.

## Related Issues

- Fixes #9 

## Tests

- https://github.com/cbdq-io/docker-grype/runs/1640231724?check_suite_focus=true

## Maintainer Use Only

- [x] Suitable tests are passing.
- [x] Release version bumped in `Makefile`
- [x] New change log generated (`make changelog`)
