### PR TITLE
Allow the user to login to Docker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,16 +3,17 @@ name: CD
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   schedule:
-#            ┌───────────── minute (0 - 59)
-#            │ ┌───────────── hour (0 - 23)
-#            │ │ ┌───────────── day of the month (1 - 31)
-#            │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-#            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-#            │ │ │ │ │                                   
-#            │ │ │ │ │
-#            │ │ │ │ │
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │ ┌───────────── day of the month (1 - 31)
+    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │ │ │ │ │
+    #        │ │ │ │ │
+    #        │ │ │ │ │
     - cron: '0 0 1 * *'
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,28 @@
+---
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
 
-## 1.0.3
+## 1.1.0
+
+### New
+
+* All the user to login to Docker. [Ben Dalling]
+
+* YAML Lint Check. [Ben Dalling]
+
+
+## 1.0.3 (2021-01-03)
 
 ### Fix
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.0.3
+TAG = 1.1.0
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TAG = 1.0.3
 all: lint build test
 
 build:
-	docker build -f docker-grype/Dockerfile -t cbdq/docker-grype:$(TAG) -t cbdq/docker-grype:latest -t docker-grype:$(TAG) -t docker-grype:latest docker-grype
+	docker build -f docker-grype/Dockerfile --no-cache -t cbdq/docker-grype:$(TAG) -t cbdq/docker-grype:latest -t docker-grype:$(TAG) -t docker-grype:latest docker-grype
 
 changelog:
 	UNRELEASED_VERSION_LABEL=$(TAG) gitchangelog > CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ cleanall: clean
 	docker system prune --force --volumes
 
 lint:
+	yamllint -s .
 	flake8 docker-grype/parse-grype-json.py
 	pycodestyle -v tests
 	docker run --rm -i hadolint/hadolint < docker-grype/Dockerfile

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Wrap [Anchore Grype](https://github.com/anchore/grype) Inside Docker
 
 ## Environment Variables
 
+- `DOCKER_PASSWORD` (_optional_): If used with `DOCKER_USERNAME` (and
+  optionally with `DOCKER_SERVER`) will login to Docker to transfer the image
+  for scanning.
+- `DOCKER_SERVER` (_optional_): Can be used with `DOCKER_USERNAME` and
+  `DOCKER_PASSWORD` to specify a server to login to before transferring the
+  image for scanning.
+- `DOCKER_USERNAME` (_optional_): If used with `DOCKER_PASSWORD` (and
+  optionally with `DOCKER_SERVER`) will login to Docker to transfer the image
+  for scanning.
 - `IMAGE_NAME` (_required_):  The name of the image to be scanned.
 - `LOG_LEVEL` (default is `INFO`):  The log level for how much output to be provided.  Can be set to
   DEBUG, INFO, WARNING, ERROR or CRITICAL.
@@ -17,7 +26,7 @@ Wrap [Anchore Grype](https://github.com/anchore/grype) Inside Docker
 
 ### Docker Compose
 
-Tested on Ubuntu.  This snippet contains
+Tested on Ubuntu and Mac OS (Big Sur).  This snippet contains
 an example configuration that will test the `hello-world:latest` image.
 
 ```YAML
@@ -42,7 +51,9 @@ services:
       - docker
     environment:
       DOCKER_HOST: tcp://docker:2375
+      DOCKER_PASSWORD: "${DOCKER_PASSWORD- }"
       DOCKER_TLS_CERTDIR: ""
+      DOCKER_USERNAME: "${DOCKER_USERNAME- }"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -5,7 +5,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # hadolint ignore=DL3008
-RUN apt-get update \
+RUN apt-get clean \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
        apt-transport-https \
        ca-certificates \

--- a/docker-grype/docker-grype-cmd.sh
+++ b/docker-grype/docker-grype-cmd.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 
+set -e
+
 if [ -z "$IMAGE_NAME" ]; then
   echo 'ERROR: The IMAGE_NAME environment variable is not set.'
+  exit 2
+fi
+
+if [ ! -z "${DOCKER_USERNAME}" -a -z "${DOCKER_PASSWORD}" ]; then
+  echo "ERROR: You must provide DOCKER_USERNAME and DOCKER_PASSWORD together."
+  exit 2
+elif [ -z "${DOCKER_USERNAME}" -a ! -z "${DOCKER_PASSWORD}" ]; then
+  echo "ERROR: You must provide DOCKER_USERNAME and DOCKER_PASSWORD together."
   exit 2
 fi
 
@@ -30,5 +40,12 @@ while [ $docker_available -ne 1 ]; do
     docker_available=1
   fi
 done
+
+if [ ! -z "${DOCKER_USERNAME}" ]; then
+  echo "INFO: Logging into Docker with provided credentials"
+  echo "${DOCKER_PASSWORD}" | docker login --password-stdin \
+                                --username "${DOCKER_USERNAME}" \
+                                "${DOCKER_SERVER}"
+fi
 
 /usr/local/bin/grype $IMAGE_NAME -o json -v | /usr/local/bin/parse-grype-json.py

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       - docker
     environment:
       DOCKER_HOST: tcp://docker:2375
+      DOCKER_PASSWORD: "${DOCKER_PASSWORD- }"
       DOCKER_TLS_CERTDIR: ""
+      DOCKER_USERNAME: "${DOCKER_USERNAME- }"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ packaging==20.8
 paramiko==2.7.2
 parse==1.18.0
 parse-type==0.5.2
+pathspec==0.8.1
 pluggy==0.13.1
 py==1.10.0
 pycodestyle==2.6.0
@@ -50,4 +51,5 @@ toml==0.10.2
 typing-extensions==3.7.4.3
 urllib3==1.26.2
 websocket-client==0.57.0
+yamllint==1.25.0
 zipp==3.4.0


### PR DESCRIPTION
# Pull Request

## Description

Allow the user to login to Docker by providing the following optional environment variables:

- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`
- `DOCKER_SERVER`

## Tests

No tests specifically for this change as it is the command shell being edited.  Nonetheless tests ran at https://github.com/cbdq-io/docker-grype/runs/1673605061?check_suite_focus=true

## Related Issues

- Fixes #11 

## Maintainer Use Only

Changes to the code for these steps should be committed with a message
similar to `chg: doc: Release X.Y.Z [skip ci], !minor` so that CI tests are
skipped for these minor changes and also don't appear in the change log.

- [x] Suitable tests are passing.
- [x] Release version bumped in `Makefile`
- [x] New change log generated (`make changelog`)
