### PR TITLE
Fix Errors in Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 
-## 1.1.0
+## 1.1.1
+
+### Fix
+
+* Correct the example Docker Compose. [Ben Dalling]
+
+
+## 1.1.0 (2021-01-09)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.1.0
+TAG = 1.1.1
 
 all: lint build test
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ services:
       - docker
     environment:
       DOCKER_HOST: tcp://docker:2375
-      DOCKER_PASSWORD: "${DOCKER_PASSWORD- }"
+      DOCKER_PASSWORD: "${DOCKER_PASSWORD-}"
       DOCKER_TLS_CERTDIR: ""
-      DOCKER_USERNAME: "${DOCKER_USERNAME- }"
+      DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -19,9 +19,9 @@ services:
       - docker
     environment:
       DOCKER_HOST: tcp://docker:2375
-      DOCKER_PASSWORD: "${DOCKER_PASSWORD- }"
+      DOCKER_PASSWORD: "${DOCKER_PASSWORD-}"
       DOCKER_TLS_CERTDIR: ""
-      DOCKER_USERNAME: "${DOCKER_USERNAME- }"
+      DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
 


### PR DESCRIPTION
# Pull Request

## Description

The example code in the README had a bug in it if executed by a user.

## Maintainer Use Only

Changes to the code for these steps should be committed with a message
similar to `chg: doc: Release X.Y.Z [skip ci], !minor` so that CI tests are
skipped for these minor changes and also don't appear in the change log.

- [x] Release version bumped in `Makefile`
- [x] New change log generated (`make changelog`)
