### PR TITLE
CVE-2019-25013, CVE-2020-27843 & CVE-2020-27844.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.1.1
+## 1.1.2
+
+### New
+
+* Added CVE-2019-25013 to the allowed list. [Ben Dalling]
+
+### Fix
+
+* Resolve CVE-2020-27843 & CVE-2020-27844. [Ben Dalling]
+
+
+## 1.1.1 (2021-01-09)
 
 ### Fix
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.1.1
+TAG = 1.1.2
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 	pycodestyle -v tests
 	docker run --rm -i hadolint/hadolint < docker-grype/Dockerfile
 
-push: build
+push: test build
 	echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
 	docker push cbdq/docker-grype:$(TAG)
 	docker push cbdq/docker-grype:latest

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ test:
 	pytest -o cache_dir=/tmp/.pycache -v tests
 	docker-compose -f tests/resources/docker-compose.yml exec -T docker \
 	    docker build -t docker-grype:latest ./docker-grype
-	docker-compose -f tests/resources/docker-compose.yml run -e 'LOG_LEVEL=DEBUG' -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2018-20225,CVE-2020-29363' sut
+	docker-compose -f tests/resources/docker-compose.yml run -e 'LOG_LEVEL=DEBUG' -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2018-20225,CVE-2019-25013,CVE-2020-29363' sut

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -7,6 +7,7 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 # hadolint ignore=DL3008
 RUN apt-get clean \
     && apt-get update \
+    && apt-get -y dist-upgrade \
     && apt-get install -y --no-install-recommends \
        apt-transport-https \
        ca-certificates \
@@ -23,20 +24,19 @@ RUN apt-get clean \
     && apt-get install -y --no-install-recommends \
        docker-ce docker-ce-cli containerd.io \
     && apt-get purge -y \
-       python2.7-minimal \
-       linux-libc-dev \
-       linux-libc-dev \
-       linux-libc-dev \
-       linux-libc-dev \
-       linux-libc-dev \
-       python2.7 \
-       libpython2.7-stdlib \
-       libbluetooth-dev \
-       libpq-dev \
        libbluetooth3 \
-       libpython2.7-minimal \
+       libbluetooth-dev \
+       libc-dev-bin \
+       libopenjp2-7 \
        libp11-kit-dev \
        libpq5 \
+       libpq-dev \
+       libpython2.7-minimal \
+       libpython2.7-stdlib \
+       linux-libc-dev \
+       python2.7 \
+       python2.7-minimal \
+    && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/step_defs/test_allowed_list.py
+++ b/tests/step_defs/test_allowed_list.py
@@ -38,7 +38,8 @@ def test_file_is_set():
 @when('CVE-2018-12886 in the allowed list')
 def cve201812886_in_the_allowed_list(feature_data):
     """CVE-2018-12886 in the allowed list."""
-    os.environ['VULNERABILITIES_ALLOWED_LIST'] = 'CVE-2018-12886'
+    allowed_list = ['CVE-2018-12886', 'CVE-2019-25013']
+    os.environ['VULNERABILITIES_ALLOWED_LIST'] = ','.join(allowed_list)
     host = testinfra.get_host(feature_data['host_url'])
     cmd = host.run(feature_data['command'])
     feature_data['stdout'] = cmd.stdout


### PR DESCRIPTION
# Pull Request

## Description

Adds CVE-2019-25013 to the allowed list and resolves CVE-2020-27843 & CVE-2020-27844.

## Tests

https://github.com/cbdq-io/docker-grype/runs/1728930557?check_suite_focus=true

## Related Issues

Fixes #16 

## Maintainer Use Only

Changes to the code for these steps should be committed with a message
similar to `chg: doc: Release X.Y.Z [skip ci], !minor` so that CI tests are
skipped for these minor changes and also don't appear in the change log.

- [x] Suitable tests are passing.
- [x] Release version bumped in `Makefile`
- [x] New change log generated (`make changelog`)
