### PR TITLE
new: Warn if an entry in allowed list is not found in the scan.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 
-## 1.1.2
+## 1.2.0
+
+### New
+
+* Warn if an entry in allowed list is not found in the scan. [Ben Dalling]
+
+
+## 1.1.2 (2021-01-19)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.1.2
+TAG = 1.2.0
 
 all: lint build test
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Wrap [Anchore Grype](https://github.com/anchore/grype) Inside Docker
   return code.  Valid values (in increasing order of severity) are `Unknown`, `Negligible`, `Low`,
   `Medium`, `High` or `Critical`.
 - `VULNERABILITIES_ALLOWED_LIST` (optional): A comma separated list of vulnerabilities that are not to count against
-  a failure (e.g. `CVE-2018-20225,CVE-2020-29363`).
+  a failure (e.g. `CVE-2018-20225,CVE-2020-29363`).  If a vulnerability is
+  specified in this variable, but not found in the scan, a warning will
+  be displayed.
 
 ## Examples
 

--- a/docker-grype/parse-grype-json.py
+++ b/docker-grype/parse-grype-json.py
@@ -88,6 +88,7 @@ class ParseGrypeJSON():
             raise ValueError(error_message)
 
         vulnerabilities = Vulnerabilities()
+        unused_allowed_vulnerabilities = self.vulnerabilities_allowed_list()
         filename = self.filename()
 
         if filename:
@@ -115,7 +116,8 @@ class ParseGrypeJSON():
             if level <= self.tolerance_level():
                 pass
             elif vulnerability_id in self.vulnerabilities_allowed_list():
-                pass
+                if vulnerability_id in unused_allowed_vulnerabilities:
+                    unused_allowed_vulnerabilities.remove(vulnerability_id)
             else:
                 self.max_severity_level(level)
                 vulnerabilities.add(
@@ -126,6 +128,13 @@ class ParseGrypeJSON():
                 )
 
         print(vulnerabilities)
+
+        if len(unused_allowed_vulnerabilities):
+            for vulnerability_id in unused_allowed_vulnerabilities:
+                msg = f'"{vulnerability_id}" is in the allowed list '
+                msg += 'but not found in the scan!'
+                logging.warning(msg)
+
         logging.debug(
             f'Max severity level found was {self.max_severity_level()}.')
 

--- a/tests/features/allowed_list.feature
+++ b/tests/features/allowed_list.feature
@@ -9,3 +9,7 @@ Feature: Allowed List
   Scenario: With allowed list
     When CVE-2018-12886 in the allowed list
     Then expect no issues in stdout
+
+  Scenario: With unnecessary vulnerability id in allowed list
+    When CVE-0000-42 in the allowed list
+    Then expect CVE-0000-42 in stderr

--- a/tests/step_defs/test_allowed_list.py
+++ b/tests/step_defs/test_allowed_list.py
@@ -23,6 +23,12 @@ def test_with_allowed_list():
     """With allowed list."""
 
 
+@scenario('../features/allowed_list.feature',
+          'With unnecessary vulnerability id in allowed list')
+def test_with_unnecessary_vulnerability_id_in_allowed_list():
+    """With unnecessary vulnerability id in allowed list."""
+
+
 @given('test file is set', target_fixture='feature_data')
 def test_file_is_set():
     """test file is set."""
@@ -33,6 +39,21 @@ def test_file_is_set():
         'command': f'{script} {filename}',
         'host_url': 'local://'
     }
+
+
+@when('CVE-0000-42 in the allowed list')
+def cve000042_in_the_allowed_list(feature_data):
+    """CVE-0000-42 in the allowed list."""
+    allowed_list = [
+        'CVE-0000-42',
+        'CVE-2018-12886',
+        'CVE-2019-25013'
+    ]
+    os.environ['VULNERABILITIES_ALLOWED_LIST'] = ','.join(allowed_list)
+    host = testinfra.get_host(feature_data['host_url'])
+    cmd = host.run(feature_data['command'])
+    feature_data['stderr'] = cmd.stderr
+    feature_data['stdout'] = cmd.stdout
 
 
 @when('CVE-2018-12886 in the allowed list')
@@ -51,6 +72,12 @@ def no_allowed_list_provided(feature_data):
     host = testinfra.get_host(feature_data['host_url'])
     cmd = host.run(feature_data['command'])
     feature_data['stdout'] = cmd.stdout
+
+
+@then('expect CVE-0000-42 in stderr')
+def expect_cve000042_in_stderr(feature_data):
+    """expect CVE-0000-42 in stdout."""
+    assert 'CVE-0000-42' in feature_data['stderr']
 
 
 @then('expect CVE-2018-12886 in stdout')


### PR DESCRIPTION
# Pull Request

## Description

If a vulnerability ID is in the allowed list, but not found in the scan, display a warning.

## Tests

https://github.com/cbdq-io/docker-grype/runs/1729708883?check_suite_focus=true#step:7:32

## Related Issues

Fixes #15

## Maintainer Use Only

Changes to the code for these steps should be committed with a message
similar to `chg: doc: Release X.Y.Z [skip ci], !minor` so that CI tests are
skipped for these minor changes and also don't appear in the change log.

- [x] Suitable tests are passing.
- [x] Release version bumped in `Makefile`
- [x] New change log generated (`make changelog`)
