### PR TITLE
FIX CVE-2021-3177

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,6 @@ Provide a description of the pull request.
 See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
 about linking issues to a pull request.
 
-List of related issues.
+## List of related issues.
+
+-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 # Changelog
 
 
-## 1.3.0
+## 1.3.1
+
+### New
+
+* Document persisting the Grype DB. [Ben Dalling]
+
+### Changes
+
+* Docker Compose example testing on MacOS. [Ben Dalling]
+
+### Fix
+
+* Remove CVE-2020-29363 and add CVE-2021-3177 to the allowed list. [Ben Dalling]
+
+
+## 1.3.0 (2021-01-28)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.3.0
+TAG = 1.3.1
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,6 @@ test:
 	pytest -o cache_dir=/tmp/.pycache -v tests
 	docker-compose -f tests/resources/docker-compose.yml exec -T docker \
 	    docker build -t docker-grype:latest ./docker-grype
-	docker-compose -f tests/resources/docker-compose.yml run -e 'LOG_LEVEL=DEBUG' -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2018-20225,CVE-2019-25013,CVE-2020-29363' sut
+	docker-compose -f tests/resources/docker-compose.yml \
+	  run -e 'LOG_LEVEL=DEBUG' \
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2018-20225,CVE-2019-25013,CVE-2021-3177' sut

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ services:
       DOCKER_TLS_CERTDIR: ""
     image: docker:18-dind
     privileged: yes
-    volumes:
-      - certs:/certs/client
-      - ../..:/work
-    working_dir: /work
 
   grype:
     container_name: grype
@@ -62,9 +58,13 @@ services:
       DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
+    volumes:
+      # This will persist the Grype DB so that it will
+      # not need to be downloaded for each invocation.
+      - grype_db:/root/.cache/grype
 
 volumes:
-  certs:
+  grype_db:
 ```
 
 This could be used by running the command (in the same directory as the

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ services:
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_PASSWORD: "${DOCKER_PASSWORD-}"
-      DOCKER_TLS_CERTDIR: ""
       DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_PASSWORD: "${DOCKER_PASSWORD-}"
-      DOCKER_TLS_CERTDIR: ""
       DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -8,10 +8,6 @@ services:
       DOCKER_TLS_CERTDIR: ""
     image: docker:18-dind
     privileged: yes
-    volumes:
-      - certs:/certs/client
-      - ../..:/work
-    working_dir: /work
 
   grype:
     container_name: grype
@@ -24,6 +20,3 @@ services:
       DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
-
-volumes:
-  certs:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -20,3 +20,10 @@ services:
       DOCKER_USERNAME: "${DOCKER_USERNAME-}"
       IMAGE_NAME: hello-world:latest
     image: cbdq/docker-grype:latest
+    volumes:
+      # This will persist the Grype DB so that it will
+      # not need to be downloaded for each invocation.
+      - grype_db:/root/.cache/grype
+
+volumes:
+  grype_db:


### PR DESCRIPTION
# Pull Request

## Description

Unfortunately, between the time of you approving #21 and my attempting to merge it, the vulnerability DB was updated and found new issues.  Therefore this one is all ready for deploying (new tag and the CHANGELOG has already been primed), so if all looks OK, please go ahead and merge.

### Allowed Vulnerabilities List

- Add CVE-2021-3177.
- Remove CVE-2020-29363 as it is no longer being detected.

### Documentation Updates
This updates the Docker Compose example (a preview can be seen at https://github.com/cbdq-io/docker-grype/tree/bugfix/CVE-2021-3177#docker-compose).  The new example:

- Removes unnecessary volumes.
- Documents how to persist the Grype DB

## Related Issues

See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
about linking issues to a pull request.

## List of related issues.

- Partially implements #19
- Fixes #22 
