### PR TITLE
Feature/grype 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 1.3.4
+## 1.4.0
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Fix
 
+* CVE-2018-20225 no longer an issue. [Ben Dalling]
+
+* Purge config durng autoremove. [Ben Dalling]
+
 * Correct the number of columns in the vulnerability report. [Ben Dalling]
 
 * Correct example code highlighting. [Ben Dalling]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,24 @@
 
 ### Changes
 
+* Bump Grype version from 0.7.0 to 0.8.0. [Ben Dalling]
+
 * Update Drone CI example. [Ben Dalling]
 
 ### Fix
 
 * Correct the number of columns in the vulnerability report. [Ben Dalling]
 
-
-## 1.3.3 (2021-03-04)
-
-### Fix
-
 * Correct example code highlighting. [Ben Dalling]
 
 ### Other
+
+* Build(deps): bump urllib3 from 1.26.2 to 1.26.3. [dependabot[bot]]
+
+  Bumps [urllib3](https://github.com/urllib3/urllib3) from 1.26.2 to 1.26.3.
+  - [Release notes](https://github.com/urllib3/urllib3/releases)
+  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
+  - [Commits](https://github.com/urllib3/urllib3/compare/1.26.2...1.26.3)
 
 * Build(deps): bump cryptography from 3.3.1 to 3.3.2. [dependabot[bot]]
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2018-20225,CVE-2019-25013,CVE-2021-3177' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-3177' sut

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.3.4
+TAG = 1.4.0
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get clean \
        linux-libc-dev \
        python2.7 \
        python2.7-minimal \
-    && apt-get -y autoremove \
+    && apt-get -y autoremove --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ snowballstemmer==2.0.0
 texttable==1.6.3
 toml==0.10.2
 typing-extensions==3.7.4.3
-urllib3==1.26.2
+urllib3==1.26.3
 websocket-client==0.57.0
 yamllint==1.25.0
 zipp==3.4.0

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.7.0            |
+    | 0.8.0            |


### PR DESCRIPTION
# Pull Request

## Description

Grype has been released as 0.8.0.  GitHub has also identified a required patch for security (#29) and that PR has been pulled into this branch.

## Related Issues
- Fixes #30.
