### PR TITLE
Hotfix/1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,21 @@
 # Changelog
 
 
-## 1.4.0
+## 1.4.1
 
 ### Changes
 
+* Bump base image from Python 3.8 to 3.9.2. [Ben Dalling]
+
 * Bump Grype version from 0.7.0 to 0.8.0. [Ben Dalling]
 
-* Update Drone CI example. [Ben Dalling]
-
 ### Fix
+
+* Add CVE-2021-20231 and CVE-2021-20232 to the whitelist. [Ben Dalling]
 
 * CVE-2018-20225 no longer an issue. [Ben Dalling]
 
 * Purge config durng autoremove. [Ben Dalling]
-
-* Correct the number of columns in the vulnerability report. [Ben Dalling]
-
-* Correct example code highlighting. [Ben Dalling]
 
 ### Other
 
@@ -27,6 +25,26 @@
   - [Release notes](https://github.com/urllib3/urllib3/releases)
   - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
   - [Commits](https://github.com/urllib3/urllib3/compare/1.26.2...1.26.3)
+
+
+## 1.3.4 (2021-03-04)
+
+### Changes
+
+* Update Drone CI example. [Ben Dalling]
+
+### Fix
+
+* Correct the number of columns in the vulnerability report. [Ben Dalling]
+
+
+## 1.3.3 (2021-03-04)
+
+### Fix
+
+* Correct example code highlighting. [Ben Dalling]
+
+### Other
 
 * Build(deps): bump cryptography from 3.3.1 to 3.3.2. [dependabot[bot]]
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-3177' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-3177,CVE-2021-20231,CVE-2021-20232' sut

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.4.0
+TAG = 1.4.1
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9.2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes issues when trying to release 1.4.0.  Bumps the base image from Python 3.8 to 3.9.2.  We also added CVE-2021-20231 and CVE-2021-20232 to the accepted list as we can't upgrade [yet] or remove the version installed.

## List of related issues.

- Fixes #32 
