### PR TITLE
Hotfix/1.5.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,4 @@ Provide a description of the pull request.
 See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
 about linking issues to a pull request.
 
-## List of related issues.
-
 -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches-ignore:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,36 @@
 # Changelog
 
 
-## 1.4.1
+## 1.5.0
+
+### Changes
+
+* Grype updated from 0.8.0 to 0.9.0. [Ben Dalling]
+
+### Fix
+
+* CVE-2021-3177 no longer being idendified as a vulnerability. [Ben Dalling]
+
+* Sort out the template for pull requests. [Ben Dalling]
+
+### Other
+
+* Build(deps): bump urllib3 from 1.26.3 to 1.26.4. [dependabot[bot]]
+
+  Bumps [urllib3](https://github.com/urllib3/urllib3) from 1.26.3 to 1.26.4.
+  - [Release notes](https://github.com/urllib3/urllib3/releases)
+  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
+  - [Commits](https://github.com/urllib3/urllib3/compare/1.26.3...1.26.4)
+
+* Build(deps): bump pyyaml from 5.3.1 to 5.4. [dependabot[bot]]
+
+  Bumps [pyyaml](https://github.com/yaml/pyyaml) from 5.3.1 to 5.4.
+  - [Release notes](https://github.com/yaml/pyyaml/releases)
+  - [Changelog](https://github.com/yaml/pyyaml/blob/master/CHANGES)
+  - [Commits](https://github.com/yaml/pyyaml/compare/5.3.1...5.4)
+
+
+## 1.4.1 (2021-03-23)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.4.1
+TAG = 1.5.0
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-3177,CVE-2021-20231,CVE-2021-20232' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-20231,CVE-2021-20232' sut

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ snowballstemmer==2.0.0
 texttable==1.6.3
 toml==0.10.2
 typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 websocket-client==0.57.0
 yamllint==1.25.0
 zipp==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytest-bdd==4.0.2
 pytest-cov==2.10.1
 pytest-testinfra==6.1.0
 python-dotenv==0.15.0
-PyYAML==5.3.1
+PyYAML==5.4
 requests==2.25.1
 six==1.15.0
 snowballstemmer==2.0.0

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.8.0            |
+    | 0.9.0            |


### PR DESCRIPTION
# Pull Request

Please merge immediately upon approval.

## Description

- Grype updated from 0.8.0 to 0.9.0.
- [CVE-2021-3177](https://nvd.nist.gov/vuln/detail/CVE-2021-3177) has been patched in the image.
- Fix pull request templates.
- Combines dependapot PRs (see _Related Issues_).

## Related Issues

- #34 
- #35
