### PR TITLE
Bugfix/grype 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.5.1
+## 1.5.2
+
+### Fix
+
+* Correct lint issue in Dockerfile. [Ben Dalling]
+
+* Bump the expected version of Grype tp 0.11.0. [Ben Dalling]
+
+* Bump base Docker image for 3.9.4. [Ben Dalling]
+
+
+## 1.5.1 (2021-04-12)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.5.1
+TAG = 1.5.2
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.2
+FROM python:3.9.4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -37,9 +37,8 @@ RUN apt-get clean \
        python2.7-minimal \
     && apt-get -y autoremove --purge \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
 COPY docker-grype-cmd.sh /usr/local/bin/docker-grype-cmd.sh
 COPY parse-grype-json.py /usr/local/bin/parse-grype-json.py

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.9.0            |
+    | 0.11.0            |


### PR DESCRIPTION
# Pull Request

## Description

- Bump the base Docker image for Python to 3.9.4 (latest stable).
- Bump version of Grype from 0.9.0 to 0.11.0.
- Fix a lint issue that was identified by the lates version of Hadolint.

## Related Issues

Our periodic rebuild of the image failed at https://github.com/cbdq-io/docker-grype/runs/2480061067?check_suite_focus=true
