### PR TITLE
Release/1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
 
-## 1.5.2
+## 1.6.0
+
+### Changes
+
+* Bump Grype version from 0.11.0 to 0.12.1. [Ben Dalling]
+
+### Fix
+
+* Resolve CVE-2021-3517. [Ben Dalling]
+
+* Resolve CVE-2018-20225, CVE-2018-25011, CVE-2018-25014, CVE-2020-36328 & CVE-2020-36329. [Ben Dalling]
+
+
+## 1.5.2 (2021-05-04)
 
 ### Fix
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.5.2
+TAG = 1.6.0
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -32,12 +32,14 @@ RUN apt-get clean \
        libpq-dev \
        libpython2.7-minimal \
        libpython2.7-stdlib \
+       libwebp-dev \
        linux-libc-dev \
        python2.7 \
        python2.7-minimal \
     && apt-get -y autoremove --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
+    && pip uninstall -y pip \
     && wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
 COPY docker-grype-cmd.sh /usr/local/bin/docker-grype-cmd.sh

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get clean \
        libpython2.7-minimal \
        libpython2.7-stdlib \
        libwebp-dev \
+       libxml2 \
        linux-libc-dev \
        python2.7 \
        python2.7-minimal \

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.11.0            |
+    | 0.12.1            |


### PR DESCRIPTION
# Pull Request

## Description

This PR delivers the following:
- Bumps the version of Grype deployed from 0.11.0 to 0.12.2.
- Fixed the following security vulnerabilities that had been identified:
  - CVE-2018-20255
  - CVE-2018-25011
  - CVE-2018-25014
  - CVE-2020-36328
  - CVE-2020-36329
  - CVE-2021-3517

Please go ahead and merge if all is OK to create a new artefact.