### PR TITLE
Bugfix/CVE 2021 3520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.7.0
+## 1.7.1
+
+### Changes
+
+* Bump base (Python) image from 3.9.4 to 3.9.5. [Ben Dalling]
+
+### Fix
+
+* Remove CVE-2021-20231, CVE-2021-20232 and CVE-2021-20305 from the allowed list. [Ben Dalling]
+
+
+## 1.7.0 (2021-06-09)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-20231,CVE-2021-20232,CVE-2021-20305,CVE-2021-33574' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-33574' sut

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.7.0
+TAG = 1.7.1
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.4
+FROM python:3.9.5
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
# Pull Request

## Description

While investigating and fixing #43 we also noticed that the previously allowed vulnerabilities were no longer being found in the newly built images (CVE-2021-20231, CVE-2021-20232 and CVE-2021-20305).

## Related Issues
- Fixes #37 
- Fixes #43
