### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
 
-## 1.7.1
+## 1.7.2
+
+### Changes
+
+* Bump base Python image to latest stable (3.9.6). [Ben Dalling]
+
+* Bump expected Grype version from 0.13.0 to 0.15.0. [Ben Dalling]
+
+
+## 1.7.1 (2021-07-05)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.7.1
+TAG = 1.7.2
 
 all: lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5
+FROM python:3.9.6
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.13.0            |
+    | 0.15.0           |


### PR DESCRIPTION
# Pull Request

## Description

This PR provides the following:

- Installs the new release of Anchore Grype (0.15.0).
- Bumps the base Python image from 3.9.5 to the latest stable (3.9.6).
