### PR TITLE
Feature/grype 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
 
-## 1.7.2
+## 1.8.0
+
+### Changes
+
+* Bump the Grype version from 0.15.0 to 0.17.0. [Ben Dalling]
+
+### Fix
+
+* Add CVE-2021-29921 to VULNERABILITIES_ALLOWED_LIST. [Ben Dalling]
+
+* Remove CVE-2019-25013 from VULNERABILITIES_ALLOWED_LIST. [Ben Dalling]
+
+
+## 1.7.2 (2021-07-17)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.7.2
+TAG = 1.8.0
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2019-25013,CVE-2021-33574' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2021-33574' sut

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2021-33574' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2021-29921,CVE-2021-33574' sut

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.15.0           |
+    | 0.17.0           |


### PR DESCRIPTION
# Pull Request

## Description

The PR provides the following:
- Bumps the version of Grype deployed in our image from 0.15.0 to 0.17.0.
- The latest base image no longer contains the CVE-2019-25013 vulnerability.
- We have a new vulnerability we have to allow.  This has been raised as #47.

## Related Issues

- Fixes #46 
