### PR TITLE
Bump Grype version from 0.23.0 to 0.24.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
 
-## 1.9.0
+## 1.10.0
+
+### Changes
+
+* Bump expected Grype version from 0.24.0 to 0.24.1. [Ben Dalling]
+
+* Bump Grype version from 0.23.0 to 0.24.0. [Ben Dalling]
+
+### Fix
+
+* Add to the VULNERABILITIES_ALLOWED_LIST. [Ben Dalling]
+
+
+## 1.9.0 (2021-10-20)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.9.0
+TAG = 1.10.0
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test:
 	    docker build -t docker-grype:latest ./docker-grype
 	docker-compose -f tests/resources/docker-compose.yml \
 	  run -e 'LOG_LEVEL=DEBUG' \
-              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2021-29921,CVE-2021-33574' sut
+              -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2017-7297,CVE-2019-13139,CVE-2019-13509,CVE-2019-16884,CVE-2019-5736,CVE-2021-43396,CVE-2021-29921,CVE-2021-33574,CVE-2021-43396,GHSA-25xm-hr59-7c27,GHSA-c3xm-pvg7-gh7r' sut

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.23.0           |
+    | 0.24.0           |

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.24.0           |
+    | 0.24.1           |


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the version of Grype in our distributed image from 0.23.0 to 0.24.1.

## Related Issues

- Fixes #50 
