### PR TITLE
Pipeline Upgrades

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -157,10 +157,35 @@ tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
 ##
 ## This label will be used as the changelog Title of the last set of changes
 ## between last valid tag and HEAD if any.
-import os.path
+import json
+import logging
+import os
+import sys
+import urllib3
+
+logger = logging.getLogger('gitchangelog')
 unreleased_version_label = os.environ['UNRELEASED_VERSION_LABEL']
+repo_tags = []
 
+if 'GITHUB_EVENT_NAME' in os.environ:
+    github_event_name = os.environ['GITHUB_EVENT_NAME']
+else:
+    github_event_name = None
 
+if github_event_name == 'pull_request':
+    http = urllib3.PoolManager()
+    url = f'https://api.github.com/repos/{os.environ["GITHUB_REPOSITORY"]}/tags'
+    r = http.request('GET', url)
+    data = json.loads(r.data)
+
+    for tag in data:
+        repo_tags.append(tag['name'])
+
+    print(f'Checking if {unreleased_version_label} is in {repo_tags}.', file=sys.stderr)
+
+    if unreleased_version_label in repo_tags:
+        logger.error(f'The tag {unreleased_version_label} already exists.')
+        sys.exit(1)
 
 ## ``output_engine`` is a callable
 ##

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,3 +39,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create Tag
+        run: |
+          git tag $( cat wait4localstack/VERSION )
+          git push --tags
+        # TODO correct how to pick up the tag number.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   changelog:
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 
@@ -21,8 +23,15 @@ jobs:
       - name: Requirements
         run: pip install -r requirements.txt
 
-      - name: Changelog
+      - name: Commited Change Log
+        run: cat CHANGELOG.md
+
+      - name: Generated Change Log
         run: |
           make changelog
           cat CHANGELOG.md
-          git diff CHANGELOG.md
+
+      - name: Difference Between Committed and Generated Change Log
+        run: |
+          make changelog
+          cat CHANGELOG.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+---
+name: Pull Request
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Requirements
+        run: pip install -r requirements.txt
+
+      - name: Changelog
+        run: |
+          make changelog
+          cat CHANGELOG.md
+          git diff CHANGELOG.md

--- a/.yamllint
+++ b/.yamllint
@@ -27,4 +27,5 @@ rules:
     ignore: |
       tests/resources/docker-compose-self-test.yml
     level: warning
+    max: 120
   truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
 
-## 1.12.0
+## 1.13.0
+
+### Changes
+
+* Bump the base image to python:3.10.1. [Ben Dalling]
+
+* New verion of Grype (0.27.3) is available. [Ben Dalling]
+
+
+## 1.12.0 (2021-12-02)
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * New verion of Grype (0.27.3) is available. [Ben Dalling]
 
+### Fix
+
+* GHSA-c3xm-pvg7-gh7r no longer present. [Ben Dalling]
+
 
 ## 1.12.0 (2021-12-02)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.12.0
+TAG = 1.13.0
 
 all: lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ TAG = 1.12.0
 
 all: lint build test
 
-build:
+build: changelog
 	docker build -f docker-grype/Dockerfile --no-cache -t cbdq/docker-grype:$(TAG) -t cbdq/docker-grype:latest -t docker-grype:$(TAG) -t docker-grype:latest docker-grype
 
-bump_version:
-	UNRELEASED_VERSION_LABEL=$(TAG) gitchangelog > CHANGELOG.md
+bump_version: changelog
 	git add .
 	git commit -m "chg: doc: Release $(TAG), !minor"
-	git tag -a -m"v$(TAG)" $(TAG)
+
+changelog:
+	UNRELEASED_VERSION_LABEL=$(TAG) gitchangelog > CHANGELOG.md
 
 clean:
 	docker-compose -f tests/resources/docker-compose.yml down -t 0

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ test:
 	docker-compose -f tests/resources/docker-compose.yml up -d docker grype
 	pytest -o cache_dir=/tmp/.pycache -v tests
 	docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest ./docker-grype
-	docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=GHSA-c3xm-pvg7-gh7r' sut
+	docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0
+FROM python:3.10.1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.25.1           |
+    | 0.27.3           |


### PR DESCRIPTION
# Pull Request

## Description

- Bumps the version of Grype to 0.27.3.
- Bumps the base image to the latest stable Python version (3.10.1).
- Enhances the CI/CD pipelines with the following:
  - The pipeline automatically creates the git tag as part of the deployment workflow.
  - When a PR is raised it checks that the proposed version number is unique in the repository tags.  An example of this failing a pipeline can be seen at https://github.com/cbdq-io/docker-grype/runs/4552672169?check_suite_focus=true
- The GHSA-c3xm-pvg7-gh7r vulnerability (see #60) is no longer present. 

## Related Issues

- Fixes #65.
- Fixes #60.