### PR TITLE
New Version of Grype

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Tag
         run: |
-          git tag $( cat wait4localstack/VERSION )
+          make tag
           git push --tags
         # TODO correct how to pick up the tag number.
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,15 +23,11 @@ jobs:
       - name: Requirements
         run: pip install -r requirements.txt
 
-      - name: Commited Change Log
-        run: cat CHANGELOG.md
-
-      - name: Generated Change Log
+      - name: Changes in this PR Recorded in Change Log
         run: |
           make changelog
-          cat CHANGELOG.md
+          sed '/^\#\{2\} [0-9].*(/q' CHANGELOG.md
 
       - name: Difference Between Committed and Generated Change Log
         run: |
-          make changelog
-          cat CHANGELOG.md
+          git diff CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.13.0
+## 1.14.0
+
+### Changes
+
+* Anchore Grype 0.28.0 is available. [Ben Dalling]
+
+### Fix
+
+* Fix issues with tagging at release time. [Ben Dalling]
+
+
+## 1.13.0 (2021-12-17)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.13.0
+TAG = 1.13.1
 
 all: lint build test
 
@@ -29,6 +29,9 @@ push:
 	echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
 	docker push cbdq/docker-grype:$(TAG)
 	docker push cbdq/docker-grype:latest
+
+tag:
+	git tag $(TAG)
 
 test:
 	docker-compose -f tests/resources/docker-compose.yml up -d docker grype

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.13.1
+TAG = 1.14.0
 
 all: lint build test
 

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -7,4 +7,4 @@ Feature: Grype
 
     Examples:
     | expected_version |
-    | 0.27.3           |
+    | 0.28.0           |


### PR DESCRIPTION
# Pull Request

## Description

This PR bumps the version of Anchore Grype from 0.27.3 to 0.28.0.  It also fixes #67 which was a bug in the creation of the Git tag when the release was being created.

## Related Issues

- Fixes #67 
