### PR TITLE
Install Specific Grype Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
 
-## 1.15.0
+## 1.16.0
+
+### Changes
+
+* Bump Python version from 3.10.1 to 3.10.2. [Ben Dalling]
+
+* Ensure a specific version (0.33.0) of Grype is installed. [Ben Dalling]
+
+
+## 1.15.0 (2022-01-21)
 
 ### New
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-GRYPE_VERSION = v
+GRYPE_VERSION = 0.33.0
 TAG = 1.16.0
 
 all: shellcheck lint build test
 
 build: changelog
 	docker build -f docker-grype/Dockerfile \
-      --no-cache \
-      -t cbdq/docker-grype:$(TAG) \
-      -t cbdq/docker-grype:latest \
-      -t docker-grype:$(TAG) \
-      -t docker-grype:latest \
-      --build-arg GRYPE_VERSION=$(GRYPE_VERSION) \
-      docker-grype
+	  --no-cache \
+	  -t cbdq/docker-grype:$(TAG) \
+	  -t cbdq/docker-grype:latest \
+	  -t docker-grype:$(TAG) \
+	  -t docker-grype:latest \
+	  --build-arg GRYPE_VERSION=$(GRYPE_VERSION) \
+	  docker-grype
 
 bump_version: changelog
 	git add .
@@ -45,8 +45,8 @@ tag:
 	git tag $(TAG)
 
 test:
-	docker-compose -f tests/resources/docker-compose.yml up -d docker grype
-	pytest -o cache_dir=/tmp/.pycache -v tests
-	docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest ./docker-grype
-	ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
-	docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-23218,CVE-2022-23219' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml up -d docker grype
+	GRYPE_VERSION=$(GRYPE_VERSION) pytest -o cache_dir=/tmp/.pycache -v tests
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest --build-arg GRYPE_VERSION=$(GRYPE_VERSION) ./docker-grype
+	GRYPE_VERSION=$(GRYPE_VERSION) ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-23218,CVE-2022-23219' sut

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
-TAG = 1.15.0
+GRYPE_VERSION = v
+TAG = 1.16.0
 
 all: shellcheck lint build test
 
 build: changelog
-	docker build -f docker-grype/Dockerfile --no-cache -t cbdq/docker-grype:$(TAG) -t cbdq/docker-grype:latest -t docker-grype:$(TAG) -t docker-grype:latest docker-grype
+	docker build -f docker-grype/Dockerfile \
+      --no-cache \
+      -t cbdq/docker-grype:$(TAG) \
+      -t cbdq/docker-grype:latest \
+      -t docker-grype:$(TAG) \
+      -t docker-grype:latest \
+      --build-arg GRYPE_VERSION=$(GRYPE_VERSION) \
+      docker-grype
 
 bump_version: changelog
 	git add .
@@ -41,4 +49,4 @@ test:
 	pytest -o cache_dir=/tmp/.pycache -v tests
 	docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest ./docker-grype
 	ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
-	docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2021-45960,CVE-2021-46143,CVE-2022-22822,CVE-2022-22823,CVE-2022-22824,CVE-2022-22825,CVE-2022-22826,CVE-2022-22827' sut
+	docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-23218,CVE-2022-23219' sut

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10.1
+ARG GRYPE_VERSION
+FROM python:3.10.2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -45,7 +46,7 @@ RUN apt-get clean \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip uninstall -y pip \
-    && wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+    && wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin "$GRYPE_VERSION"
 
 COPY docker-grype-cmd.sh /usr/local/bin/docker-grype-cmd.sh
 COPY parse-grype-json.py /usr/local/bin/parse-grype-json.py

--- a/tests/features/grype.feature
+++ b/tests/features/grype.feature
@@ -3,8 +3,4 @@ Feature: Grype
   Scenario Outline: Grype Version
     Given the Grype container
     When the version is queried
-    Then check the version matches <expected_version>
-
-    Examples:
-    | expected_version |
-    | 0.32.0           |
+    Then check the version matches the expected version

--- a/tests/resources/docker-compose.yml
+++ b/tests/resources/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
+      GRYPE_VERSION: "${GRYPE_VERSION}"
       IMAGE_NAME: docker-grype:latest
       LOG_LEVEL: DEBUG
       ONLY_FIXED: "${ONLY_FIXED-0}"

--- a/tests/step_defs/test_grype.py
+++ b/tests/step_defs/test_grype.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 """Grype feature tests."""
+import os
+import pytest
 import testinfra
 
 from pytest_bdd import (
@@ -18,8 +20,15 @@ def test_grype_version():
 @given('the Grype container', target_fixture='test_data')
 def the_grype_container():
     """the Grype container."""
-    test_data = {}
-    test_data['host_url'] = "docker://grype"
+    try:
+        expected_version = os.environ['GRYPE_VERSION']
+        test_data = {
+            'expected_version': expected_version,
+            'host_url': "docker://grype"
+        }
+    except KeyError:
+        pytest.skip('GRYPE_VERSION not set in environment.')
+
     return test_data
 
 
@@ -35,9 +44,9 @@ def the_version_is_queried(test_data):
     test_data['grype_version'] = grype_version
 
 
-@then('check the version matches <expected_version>')
-def check_the_version_matches_expected_version(test_data, expected_version):
+@then('check the version matches the expected version')
+def check_the_version_matches_expected_version(test_data):
     """test the version matches <expected_version>."""
-    grype_version = test_data['grype_version']
-    error_message = f'Version {grype_version} != {expected_version}.'
+    actual_version = test_data['grype_version']
+    error_message = f'Version {actual_version} != {expected_version}.'
     assert grype_version == expected_version, error_message

--- a/tests/step_defs/test_grype.py
+++ b/tests/step_defs/test_grype.py
@@ -48,5 +48,6 @@ def the_version_is_queried(test_data):
 def check_the_version_matches_expected_version(test_data):
     """test the version matches <expected_version>."""
     actual_version = test_data['grype_version']
+    expected_version = test_data['expected_version']
     error_message = f'Version {actual_version} != {expected_version}.'
-    assert grype_version == expected_version, error_message
+    assert actual_version == expected_version, error_message


### PR DESCRIPTION
# Pull Request

## Description

This PR bumps the following component versions:
- Anchore Grype from 0.32.0 to 0.33.0
- The Docker image for Python from 3.10.1 to 3.10.2

It also moves to a model where the version of Grype installed is a specific version rather than just the latest.  This should stop the scenario where if there is a release of Grype between when an engineer prepares a PR in the repo and when the PR is approved, the build subsequently fails (as has happened on a couple of occasions now).

If @debney is OK with this PR, please go ahead and merge which will automatically deploy the new version of the image to Docker Hub.

## Related Issues

- Fixes #74 
