### PR TITLE
Release/1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## 1.16.0
+## 1.17.0
+
+### Changes
+
+* Bump the Grype version from 0.33.0 to 0.34.3. [Ben Dalling]
+
+### Fix
+
+* Fix build process to ensure requested version is installed. [Ben Dalling]
+
+
+## 1.16.0 (2022-02-24)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GRYPE_VERSION = 0.33.0
-TAG = 1.16.0
+TAG = 1.17.0
 
 all: shellcheck lint build test
 
@@ -11,6 +11,7 @@ build: changelog
 	  -t docker-grype:$(TAG) \
 	  -t docker-grype:latest \
 	  --build-arg GRYPE_VERSION=$(GRYPE_VERSION) \
+          --progress plain \
 	  docker-grype
 
 bump_version: changelog

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GRYPE_VERSION = 0.33.0
+GRYPE_VERSION = 0.34.3
 TAG = 1.17.0
 
 all: shellcheck lint build test
@@ -50,4 +50,4 @@ test:
 	GRYPE_VERSION=$(GRYPE_VERSION) pytest -o cache_dir=/tmp/.pycache -v tests
 	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest --build-arg GRYPE_VERSION=$(GRYPE_VERSION) ./docker-grype
 	GRYPE_VERSION=$(GRYPE_VERSION) ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
-	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-23218,CVE-2022-23219' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-3737,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-21698,CVE-2022-23218,CVE-2022-23219' sut

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,5 +1,5 @@
-ARG GRYPE_VERSION
 FROM python:3.10.2
+ARG GRYPE_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -14,7 +14,7 @@ RUN apt-get clean \
        curl \
        gnupg-agent \
        software-properties-common \
-    && wget -qO /tmp/debian.key https://download.docker.com/linux/debian/gpg \
+    && curl -so /tmp/debian.key https://download.docker.com/linux/debian/gpg \
     && apt-key add /tmp/debian.key \
     && add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/debian \
@@ -23,6 +23,7 @@ RUN apt-get clean \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        docker-ce docker-ce-cli containerd.io \
+    && curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -d -b /usr/local/bin "v${GRYPE_VERSION}" \
     && apt-get purge -y \
        curl \
        libbluetooth3 \
@@ -45,8 +46,7 @@ RUN apt-get clean \
     && apt-get -y autoremove --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip uninstall -y pip \
-    && wget -qO - https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin "$GRYPE_VERSION"
+    && pip uninstall -y pip
 
 COPY docker-grype-cmd.sh /usr/local/bin/docker-grype-cmd.sh
 COPY parse-grype-json.py /usr/local/bin/parse-grype-json.py


### PR DESCRIPTION
# Pull Request

## Description

The PR fixes a problem where the requested version of Grype wasn't installed (it went for the latest).  Once that had been proven to work, we upgraded the underlying version of Grype from 0.33.0 to 0.34.3.

## Related Issues

See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
about linking issues to a pull request.

- Fixes #76 
- Fixes #77 
