### PR TITLE
Release/1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 
 ### Changes
 
+* Add GHSA-c3xm-pvg7-gh7r, GHSA-fgv8-vj5c-2ppq & GHSA-q3j5-32m5-58c2 to the allowed list. [Ben Dalling]
+
 * Bump version of Anchore Grype from 0.34.3 to 0.34.6. [Ben Dalling]
+
+### Fix
+
+* Attempt to fix CVE-2022-0778. [Ben Dalling]
 
 
 ## 1.17.0 (2022-03-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 
 ### Changes
 
+* Bump image of Grype from 0.34.6 to 0.34.7. [Ben Dalling]
+
 * Add GHSA-c3xm-pvg7-gh7r, GHSA-fgv8-vj5c-2ppq & GHSA-q3j5-32m5-58c2 to the allowed list. [Ben Dalling]
 
 * Bump version of Anchore Grype from 0.34.3 to 0.34.6. [Ben Dalling]
 
 ### Fix
+
+* Update allowed vulnerabilities list. [Ben Dalling]
+
+* Simply build with the latest Python 3 Docker image. [Ben Dalling]
 
 * Attempt to fix CVE-2022-0778. [Ben Dalling]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 
-## 1.17.0
+## 1.18.0
+
+### Changes
+
+* Bump version of Anchore Grype from 0.34.3 to 0.34.6. [Ben Dalling]
+
+
+## 1.17.0 (2022-03-18)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GRYPE_VERSION = 0.34.3
-TAG = 1.17.0
+GRYPE_VERSION = 0.34.6
+TAG = 1.18.0
 
 all: shellcheck lint build test
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GRYPE_VERSION = 0.34.6
+GRYPE_VERSION = 0.34.7
 TAG = 1.18.0
 
 all: shellcheck lint build test

--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ test:
 	GRYPE_VERSION=$(GRYPE_VERSION) pytest -o cache_dir=/tmp/.pycache -v tests
 	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest --build-arg GRYPE_VERSION=$(GRYPE_VERSION) ./docker-grype
 	GRYPE_VERSION=$(GRYPE_VERSION) ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
-	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-3737,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-21698,CVE-2022-23218,CVE-2022-23219' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-3737,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-21698,CVE-2022-23218,CVE-2022-23219,GHSA-c3xm-pvg7-gh7r,GHSA-fgv8-vj5c-2ppq,GHSA-q3j5-32m5-58c2' sut

--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,5 @@ test:
 	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml up -d docker grype
 	GRYPE_VERSION=$(GRYPE_VERSION) pytest -o cache_dir=/tmp/.pycache -v tests
 	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml exec -T docker docker build -t docker-grype:latest --build-arg GRYPE_VERSION=$(GRYPE_VERSION) ./docker-grype
-	GRYPE_VERSION=$(GRYPE_VERSION) ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=' sut
-	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-3737,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2021-33574,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-21698,CVE-2022-23218,CVE-2022-23219,GHSA-c3xm-pvg7-gh7r,GHSA-fgv8-vj5c-2ppq,GHSA-q3j5-32m5-58c2' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) ONLY_FIXED=1 docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=GHSA-c3xm-pvg7-gh7r,GHSA-crp2-qrr5-8pq7,GHSA-fgv8-vj5c-2ppq,GHSA-q3j5-32m5-58c2' sut
+	GRYPE_VERSION=$(GRYPE_VERSION) docker-compose -f tests/resources/docker-compose.yml run --rm -e 'VULNERABILITIES_ALLOWED_LIST=CVE-2015-5237,CVE-2020-16156,CVE-2021-3737,CVE-2021-22570,CVE-2021-29921,CVE-2021-33560,CVE-2022-0391,CVE-2022-0529,CVE-2022-0530,CVE-2022-21698,GHSA-c3xm-pvg7-gh7r,GHSA-crp2-qrr5-8pq7,GHSA-fgv8-vj5c-2ppq,GHSA-q3j5-32m5-58c2' sut

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get clean \
        $(lsb_release -cs) \
        stable" \
     && apt-get update \
-    && apt-get upgrade libssl-dev \
+    && apt-get upgrade -y libssl-dev \
     && apt-get install -y --no-install-recommends \
        docker-ce docker-ce-cli containerd.io \
     && curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -d -b /usr/local/bin "v${GRYPE_VERSION}" \

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get clean \
        $(lsb_release -cs) \
        stable" \
     && apt-get update \
+    && apt-get upgrade libssl-dev \
     && apt-get install -y --no-install-recommends \
        docker-ce docker-ce-cli containerd.io \
     && curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -d -b /usr/local/bin "v${GRYPE_VERSION}" \

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.2
+FROM python:3
 ARG GRYPE_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/tests/resources/docker-compose.yml
+++ b/tests/resources/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       IMAGE_NAME: docker-grype:latest
       LOG_LEVEL: DEBUG
       ONLY_FIXED: "${ONLY_FIXED-0}"
+      SHOW_ALL_VULNERABILITIES: 1
     image: docker-grype:latest
 
 volumes:


### PR DESCRIPTION
# Pull Request

## Description

Bumps to the latest available version of Anchore Grype (0.34.6).
