### PR TITLE
Bump Grype from 0.52.0 to 0.53.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GRYPE_VERSION = 0.52.0
+GRYPE_VERSION = 0.53.1
 TAG = 1.20.4
 
 all: shellcheck lint build test


### PR DESCRIPTION
# Pull Request

## Description

Details of the changes for Grype can be seen at <https://github.com/anchore/grype/compare/v0.52.0...v0.53.1>.

