### PR TITLE
Feature/101 migrate from docker hub to GitHub container registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,16 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    #        ┌───────────── minute (0 - 59)
-    #        │ ┌───────────── hour (0 - 23)
-    #        │ │ ┌───────────── day of the month (1 - 31)
-    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #        │ │ │ │ │
-    #        │ │ │ │ │
-    #        │ │ │ │ │
-    - cron: '0 0 1 * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,10 +25,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Push
-        run: make build test push
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: make build test push_latest
 
       - name: Create Tag
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
 
       - name: Requirements
         run: pip install -r requirements.txt
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
 
       - name: Push
         run: make build test push_unstable
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,22 @@ jobs:
           coverageCommand: coverage xml
           coverageLocations: |
             ${{github.workspace}}/coverage.xml:coverage.py
+
+  push:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v3.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Requirements
+        run: pip install -r requirements.txt
+
+      - name: Push
+        run: make build test push_unstable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,30 @@
 # Changelog
 
 
-## 1.20.4
+## 1.20.5
+
+### Changes
+
+* Migrate from Docker Hub to GitHub Container Registry. [Ben Dalling]
+
+* Bump Grype from 0.52.0 to 0.53.1. [Ben Dalling]
+
+### Other
+
+* Build(deps): bump certifi from 2022.9.24 to 2022.12.7. [dependabot[bot]]
+
+  Bumps [certifi](https://github.com/certifi/python-certifi) from 2022.9.24 to 2022.12.7.
+  - [Release notes](https://github.com/certifi/python-certifi/releases)
+  - [Commits](https://github.com/certifi/python-certifi/compare/2022.09.24...2022.12.07)
+
+  ---
+  updated-dependencies:
+  - dependency-name: certifi
+    dependency-type: direct:production
+  ...
+
+
+## 1.20.4 (2022-11-15)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,12 @@ lint:
 	flake8
 	docker run --rm -i hadolint/hadolint < docker-grype/Dockerfile
 
-push:
-	echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
-	docker push cbdq/docker-grype:$(TAG)
-	docker push cbdq/docker-grype:latest
+push_latest:
+	docker push ghcr.io/cbdq-io/docker-grype:$(TAG)
+	docker push ghcr.io/cbdq-io/docker-grype:latest
+
+push_unstable:
+	docker push ghcr.io/cbdq-io/docker-grype:unstable
 
 shellcheck:
 	shellcheck docker-grype/docker-grype-cmd.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GRYPE_VERSION = 0.53.1
-TAG = 1.20.4
+TAG = 1.20.5
 
 all: shellcheck lint build test
 

--- a/docker-grype/Dockerfile
+++ b/docker-grype/Dockerfile
@@ -4,6 +4,9 @@ ARG GRYPE_VERSION
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+LABEL org.opencontainers.image.source=https://github.com/cbdq-io/docker-grype
+LABEL org.opencontainers.image.description="Wrap Anchore Grype Inside Docker"
+LABEL org.opencontainers.image.licenses=Apache-2.0
 
 # hadolint ignore=DL3008
 RUN apt-get clean \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==22.1.0
 bandit==1.7.4
 bcrypt==4.0.1
 cached-property==1.5.2
-certifi==2022.9.24
+certifi==2022.12.7
 cffi==1.15.1
 chardet==5.0.0
 charset-normalizer==2.1.1


### PR DESCRIPTION
# Pull Request

## Description

The MR does the following:
- When pushing to `main` will publish an image tagged with the SemVer tag and with a label of `latest` to the GitHub Container Registry.  This will be instead of to Docker Hub.
- When pushing to `develop` will publish and image tagged with `unstable` to the GitHub Container Registry.
- Incorporates the change in PR #106 

For more details on the GitHub Container Registry, see <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>.

## Related Issues

- Fixes #101 
